### PR TITLE
Normalize charge statute at initialization

### DIFF
--- a/src/backend/expungeservice/crawler/models/charge.py
+++ b/src/backend/expungeservice/crawler/models/charge.py
@@ -14,4 +14,4 @@ class Charge:
 
     @staticmethod
     def __strip_non_alphanumeric_chars(statute):
-        return re.sub(r'[^a-zA-Z0-9*]', '', statute)
+        return re.sub(r'[^a-zA-Z0-9*]', '', statute).upper()

--- a/src/backend/expungeservice/crawler/models/charge.py
+++ b/src/backend/expungeservice/crawler/models/charge.py
@@ -1,3 +1,5 @@
+import re
+
 from expungeservice.crawler.models.disposition import Disposition
 
 
@@ -5,7 +7,11 @@ class Charge:
 
     def __init__(self, name, statute, level, date):
         self.name = name
-        self.statute = statute
+        self.statute = Charge.__strip_non_alphanumeric_chars(statute)
         self.level = level
         self.date = date
         self.disposition = Disposition()
+
+    @staticmethod
+    def __strip_non_alphanumeric_chars(statute):
+        return re.sub(r'[^a-zA-Z0-9*]', '', statute)

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -1,0 +1,20 @@
+import unittest
+
+from expungeservice.crawler.models.charge import Charge
+
+class TestCaseWithDisposition(unittest.TestCase):
+
+    def setUp(self):
+        self.charge = {'name': 'PCS', 'level': 'Misdemeanor', 'date': '12/12/1999'}
+
+    def test_it_initializes_simple_statute(self):
+        self.charge['statute'] = '1231235b'
+        charge = Charge(**self.charge)
+
+        assert charge.statute == '1231235b'
+
+    def test_it_normalizes_statute(self):
+        self.charge['statute'] = '-123.123(5)(b)'
+        charge = Charge(**self.charge)
+
+        assert charge.statute == '1231235b'

--- a/src/backend/tests/models/test_charge.py
+++ b/src/backend/tests/models/test_charge.py
@@ -2,19 +2,26 @@ import unittest
 
 from expungeservice.crawler.models.charge import Charge
 
+
 class TestCaseWithDisposition(unittest.TestCase):
 
     def setUp(self):
         self.charge = {'name': 'PCS', 'level': 'Misdemeanor', 'date': '12/12/1999'}
 
     def test_it_initializes_simple_statute(self):
-        self.charge['statute'] = '1231235b'
+        self.charge['statute'] = '1231235B'
         charge = Charge(**self.charge)
 
-        assert charge.statute == '1231235b'
+        assert charge.statute == '1231235B'
 
     def test_it_normalizes_statute(self):
-        self.charge['statute'] = '-123.123(5)(b)'
+        self.charge['statute'] = '-123.123(5)()B'
         charge = Charge(**self.charge)
 
-        assert charge.statute == '1231235b'
+        assert charge.statute == '1231235B'
+
+    def test_it_converts_statute_to_uppercase(self):
+        self.charge['statute'] = '-123.123(5)()b'
+        charge = Charge(**self.charge)
+
+        assert charge.statute == '1231235B'


### PR DESCRIPTION
## Description

Statutes are 8 characters long and include one '.' and two parentheses,
however they're persisted to the API's database inconsistently. Created
a method to strip the statute of all characters that are not
alphanumeric. This should enable us to consistently extract the
different parts of the statute for analysis.

Fixes #60 