### PR TITLE
Add authentication endpoints

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -119,9 +119,10 @@ Global headers:
 - `Accept: application/json`
 
 
-**`POST`** `/api/login`
+**`POST`** `/api/<version>/auth_token`
 
-Logs user into system
+Post username, password to create an auth token (JWT) that can be used when
+accessing protected APIs
 
 `POST` body:
 
@@ -130,14 +131,20 @@ Logs user into system
     * `username`
     * `password`
 
-Status codes:
+Returns: auth token
 
-- `201 CREATED`: log in was successful
-- `401 UNAUTHORIZED`: log in was not succesful: user not found
+- format: `JSON`
+- fields:
+    * auth_token
+
+ Status codes:
+
+- `201 CREATED`: auth token creation successful
+- `401 UNAUTHORIZED`: unable to create auth token: invalid username / password
 - `400 BAD FORMAT`: missing username or password
 
 
-**`POST`** `/api/users/`
+**`POST`** `/api/<version>/users/`
 
 Creates a user
 
@@ -166,7 +173,7 @@ Status codes:
 - `400 BAD FORMAT`: missing one or more fields
 
 
-**`GET`** `/api/users/USERNAME`
+**`GET`** `/api/<version>/users/USERNAME`
 
 Returns: Requested user
 
@@ -182,7 +189,7 @@ Status codes:
 - `200 OK`
 
 
-**`POST`** `/api/search`
+**`POST`** `/api/<version>/search`
 
 Performs search of remote system
 
@@ -201,7 +208,7 @@ Returns: Search results
     * tbd
 
 
-**`GET`** `/stats`
+**`GET`** `/api/<version>/stats`
 
 Reports on statistics run on data
 

--- a/src/backend/expungeservice/app.py
+++ b/src/backend/expungeservice/app.py
@@ -6,7 +6,7 @@ from flask import Flask
 from .config import app_config
 
 # Add new endpoint imports here:
-from .endpoints import hello
+from .endpoints import hello, auth
 
 def create_app(env_name):
     """
@@ -19,5 +19,6 @@ def create_app(env_name):
 
     # Register endpoint routes here:
     hello.register(app)
+    auth.register(app)
 
     return app

--- a/src/backend/expungeservice/config.py
+++ b/src/backend/expungeservice/config.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 
 class Development(object):
     """
@@ -6,7 +7,8 @@ class Development(object):
     """
     DEBUG = True
     TESTING = False
-    JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY')
+    JWT_SECRET_KEY = os.urandom(24)
+    JWT_EXPIRY_TIMER = datetime.timedelta(seconds=60)
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
 
 class Production(object):
@@ -17,6 +19,7 @@ class Production(object):
     TESTING = False
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
     JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY')
+    JWT_EXPIRY_TIMER = datetime.timedelta(minutes=10)
 
 app_config = {
     'development': Development,

--- a/src/backend/expungeservice/endpoints/auth.py
+++ b/src/backend/expungeservice/endpoints/auth.py
@@ -1,0 +1,103 @@
+import jwt
+import functools
+import datetime
+import re
+
+from flask.views import MethodView
+from flask import request, abort, jsonify, current_app
+from werkzeug.security import check_password_hash, generate_password_hash
+
+# TODO temp hack - replace with table from DB
+users = {}
+
+def get_auth_token(app, username):
+    dt = datetime.datetime.utcnow()
+    payload = {
+        'iss': 'expungeservice',
+        'iat': dt,
+        'exp': dt + app.config.get('JWT_EXPIRY_TIMER'),
+        'sub': username,
+    }
+    return jwt.encode(
+        payload,
+        app.config.get('JWT_SECRET_KEY'),
+        algorithm='HS256'
+    ).decode('utf-8')
+
+def auth_required(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            auth_hdr = request.headers.get('Authorization')
+            if auth_hdr == None:
+                return 'Missing Authorization header!', 401
+
+            match = re.match('Bearer\s+(.+)', auth_hdr)
+
+            if match == None:
+                abort(400)
+
+            payload = jwt.decode(
+                match.group(1),
+                current_app.config.get('JWT_SECRET_KEY')
+            )
+
+            # TODO temp hack - replace with table from DB
+            if not payload['sub'] in users:
+                return 'Invalid auth token claim!', 401
+
+            return f(*args, **kwargs)
+        except (
+                jwt.exceptions.InvalidTokenError,
+                jwt.exceptions.InvalidSignatureError,
+        ):
+            return 'Invalid auth token!', 401
+        except jwt.exceptions.ExpiredSignatureError:
+            return 'auth token expired!', 401
+    return wrapper
+
+class Users(MethodView):
+    def post(self):
+        data = request.get_json()
+
+        if data == None:
+            abort(400)
+
+        # TODO temp hack - replace with table from DB
+        if data['username'] in users:
+            return 'User already exists! Please login', 202
+
+        users[data['username']] = generate_password_hash(data['password'])
+
+        response_data = {
+            'username': data['username'],
+            'email address': data['email address']
+        }
+
+        return jsonify(response_data), 201
+
+class AuthToken(MethodView):
+    def get(self):
+        data = request.get_json()
+
+        if data == None:
+            abort(400)
+
+        if (data['username'] not in users or
+                not check_password_hash(users[data['username']], data['password'])):
+            return 'Unauthorized', 401
+
+        response_data = {
+            'auth_token': get_auth_token(current_app, data['username'])
+        }
+        return jsonify(response_data)
+
+class ProtectedView(MethodView):
+    @auth_required
+    def get(self):
+        return 'Protected View'
+
+def register(app):
+    app.add_url_rule('/api/v0.1/users', view_func=Users.as_view('users'))
+    app.add_url_rule('/api/v0.1/auth_token', view_func=AuthToken.as_view('auth_token'))
+    app.add_url_rule('/api/v0.1/test/protected', view_func=ProtectedView.as_view('protected'))

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -1,0 +1,94 @@
+import pytest
+import os
+import time
+import datetime
+
+from flask import jsonify, current_app
+
+import expungeservice
+from expungeservice.endpoints import auth
+
+@pytest.fixture(scope='module')
+def app():
+    return expungeservice.create_app('development')
+
+@pytest.fixture(scope='module')
+def client(app):
+    return app.test_client()
+
+def test_hello(client):
+    response = client.get('/hello')
+    assert(response.data == b'Hello, world!')
+
+username = 'test_user'
+password = 'test_password'
+email = 'test_user@test.com'
+
+def create_user(client, username, password, email):
+    return client.post('api/v0.1/users', json={
+        'username': username,
+        'password': password,
+        'email address': email,
+    })
+
+def get_auth_token(client, username, password):
+    return client.get('/api/v0.1/auth_token', json={
+        'username': username,
+        'password': password,
+    })
+
+def test_create_user(client):
+    response = create_user(client, username, password, email)
+    assert(response.status_code == 201)
+
+    data = response.get_json()
+    assert(data['username'] == username)
+    assert(data['email address'] == email)
+
+def test_create_user_collision(client):
+    response = create_user(client, username, password, email)
+    assert(response.status_code == 202)
+
+def test_auth_token_valid_credentials(client):
+    response = get_auth_token(client, 'test_user', 'test_password')
+
+    assert(response.status_code == 200)
+    assert(response.headers.get('Content-type') == 'application/json')
+    data = response.get_json()
+    assert('auth_token' in data)
+    assert(len(data['auth_token']))
+
+def test_auth_token_invalid_username(client):
+    response = get_auth_token(client, 'wrong_user', 'test_password')
+    assert(response.status_code == 401)
+
+def test_login_invalid_pasword(client):
+    response = get_auth_token(client, 'test_user', 'wrong_password')
+    assert(response.status_code == 401)
+
+def test_access_valid_auth_token(client):
+    response = get_auth_token(client, 'test_user', 'test_password')
+    response = client.get('/api/v0.1/test/protected', headers={
+        'Authorization': 'Bearer {}'.format(response.get_json()['auth_token'])
+    })
+    assert(response.status_code == 200)
+
+def test_access_invalid_auth_token(client):
+    response = get_auth_token(client, 'test_user', 'test_password')
+    response = client.get('/api/v0.1/test/protected', headers={
+        'Authorization': 'Bearer {}'.format('Invalid auth token')
+    })
+    assert(response.status_code == 401)
+
+def test_access_expired_auth_token():
+    app = expungeservice.create_app('development')
+    app.config['JWT_EXPIRY_TIMER'] = datetime.timedelta(seconds=0)
+
+    client = app.test_client()
+
+    response = get_auth_token(client, 'test_user', 'test_password')
+    time.sleep(1)
+    response = client.get('/api/v0.1/test/protected', headers={
+        'Authorization': 'Bearer {}'.format(response.get_json()['auth_token'])
+    })
+    assert(response.status_code == 401)


### PR DESCRIPTION
This PR adds register, login endpoints to the backend. The login endpoint uses JWT for stateless authentication. The endpoints don't talk to the database yet.