### PR TITLE
Backend/remove username field

### DIFF
--- a/config/postgres/initdb/scripts/create-tables.sql
+++ b/config/postgres/initdb/scripts/create-tables.sql
@@ -5,7 +5,6 @@ CREATE EXTENSION citext;
 
 CREATE TABLE users (
     user_id         UUID NOT NULL,
-    username        CITEXT UNIQUE NOT NULL,
     email           CITEXT UNIQUE NOT NULL,
     admin           BOOLEAN NOT NULL DEFAULT FALSE,
     date_created    TIMESTAMP WITH TIME ZONE DEFAULT now(),

--- a/doc/design.md
+++ b/doc/design.md
@@ -19,7 +19,7 @@ User Flow
 
 User visits login page in browser
 
-User types username and password to log in
+User types email and password to log in
 
 User is directed to main page
 
@@ -70,7 +70,7 @@ These routes are set up in the front-end application for navigating between the 
 
 Login page
 
-- Form for entering `username` and `password`
+- Form for entering `email` and `password`
 - Application sends credentials to server
 - Server validates credentials
 - If credentials are good server returns session cookie (contents tbd)
@@ -101,7 +101,6 @@ Page for viewing statistics
 
 Admin page for creating users
 
-- username
 - email
 - password
 - admin permissions (T/F)
@@ -121,14 +120,14 @@ Global headers:
 
 **`POST`** `/api/<version>/auth_token`
 
-Post username, password to create an auth token (JWT) that can be used when
+Post email, password to create an auth token (JWT) that can be used when
 accessing protected APIs
 
 `POST` body:
 
 - format: `JSON`
 - fields:
-    * `username`
+    * `email`
     * `password`
 
 Returns: auth token
@@ -140,8 +139,8 @@ Returns: auth token
  Status codes:
 
 - `201 CREATED`: auth token creation successful
-- `401 UNAUTHORIZED`: unable to create auth token: invalid username / password
-- `400 BAD FORMAT`: missing username or password
+- `401 UNAUTHORIZED`: unable to create auth token: invalid email / password
+- `400 BAD FORMAT`: missing email or password
 
 
 **`POST`** `/api/<version>/users/`
@@ -152,19 +151,17 @@ Creates a user
 
 - format: `JSON`
 - fields:
-    * username
-	* encrypted password
-	* email address
+    * email
+    * encrypted password
     * admin permissions
 
 Returns: New user
 
 - format: `JSON`
 - fields:
-    * username
-    * email address
+    * email
     * admin permissions
-	* timestamp
+    * timestamp
 
 Status codes:
 
@@ -173,16 +170,15 @@ Status codes:
 - `400 BAD FORMAT`: missing one or more fields
 
 
-**`GET`** `/api/<version>/users/USERNAME`
+**`GET`** `/api/<version>/users/EMAIL`
 
 Returns: Requested user
 
 - format: `JSON`
 - fields:
-    * username
-    * email address
+    * email
     * admin permissions
-	* timestamp
+    * timestamp
 
 Status codes:
 
@@ -199,7 +195,7 @@ Performs search of remote system
 - fields:
     * first name
     * last name
-	* dob
+    * dob
 
 Returns: Search results
 
@@ -224,7 +220,7 @@ Database Schema
 
 Tables:
 
-    users (uuid, username, email, hashed_password, password_salt, admin, date_created, date_modified), uuid primary key
+    users (uuid, email, hashed_password, password_salt, admin, date_created, date_modified), uuid primary key
 
     clients (uuid, first_name, last_name, dob, date_created, date_modified), uuid primary key
 

--- a/src/backend/expungeservice/endpoints/auth.py
+++ b/src/backend/expungeservice/endpoints/auth.py
@@ -9,13 +9,13 @@ from werkzeug.security import check_password_hash
 
 from expungeservice.endpoints.users import users
 
-def get_auth_token(app, username):
+def get_auth_token(app, email):
     dt = datetime.datetime.utcnow()
     payload = {
         'iss': 'expungeservice',
         'iat': dt,
         'exp': dt + app.config.get('JWT_EXPIRY_TIMER'),
-        'sub': username,
+        'sub': email,
     }
     return jwt.encode(
         payload,
@@ -62,12 +62,12 @@ class AuthToken(MethodView):
         if data == None:
             abort(400)
 
-        if (data['username'] not in users or
-                not check_password_hash(users[data['username']], data['password'])):
+        if (data['email'] not in users or
+                not check_password_hash(users[data['email']], data['password'])):
             return 'Unauthorized', 401
 
         response_data = {
-            'auth_token': get_auth_token(current_app, data['username'])
+            'auth_token': get_auth_token(current_app, data['email'])
         }
         return jsonify(response_data)
 

--- a/src/backend/expungeservice/endpoints/users.py
+++ b/src/backend/expungeservice/endpoints/users.py
@@ -13,14 +13,13 @@ class Users(MethodView):
             abort(400)
 
         # TODO temp hack - replace with table from DB
-        if data['username'] in users:
+        if data['email'] in users:
             return 'User already exists! Please login', 202
 
-        users[data['username']] = generate_password_hash(data['password'])
+        users[data['email']] = generate_password_hash(data['password'])
 
         response_data = {
-            'username': data['username'],
-            'email address': data['email address']
+            'email': data['email']
         }
 
         return jsonify(response_data), 201

--- a/src/backend/tests/endpoints/test_auth.py
+++ b/src/backend/tests/endpoints/test_auth.py
@@ -19,37 +19,34 @@ def test_hello(client):
     response = client.get('/hello')
     assert(response.data == b'Hello, world!')
 
-username = 'test_user'
-password = 'test_password'
 email = 'test_user@test.com'
+password = 'test_password'
 
-def create_user(client, username, password, email):
+def create_user(client, email, password):
     return client.post('api/v0.1/users', json={
-        'username': username,
+        'email': email,
         'password': password,
-        'email address': email,
     })
 
-def get_auth_token(client, username, password):
+def get_auth_token(client, email, password):
     return client.get('/api/v0.1/auth_token', json={
-        'username': username,
+        'email': email,
         'password': password,
     })
 
 def test_create_user(client):
-    response = create_user(client, username, password, email)
+    response = create_user(client, email, password)
     assert(response.status_code == 201)
 
     data = response.get_json()
-    assert(data['username'] == username)
-    assert(data['email address'] == email)
+    assert(data['email'] == email)
 
 def test_create_user_collision(client):
-    response = create_user(client, username, password, email)
+    response = create_user(client, email, password)
     assert(response.status_code == 202)
 
 def test_auth_token_valid_credentials(client):
-    response = get_auth_token(client, 'test_user', 'test_password')
+    response = get_auth_token(client, 'test_user@test.com', 'test_password')
 
     assert(response.status_code == 200)
     assert(response.headers.get('Content-type') == 'application/json')
@@ -58,22 +55,22 @@ def test_auth_token_valid_credentials(client):
     assert(len(data['auth_token']))
 
 def test_auth_token_invalid_username(client):
-    response = get_auth_token(client, 'wrong_user', 'test_password')
+    response = get_auth_token(client, 'wrong_user@test.com', 'test_password')
     assert(response.status_code == 401)
 
 def test_login_invalid_pasword(client):
-    response = get_auth_token(client, 'test_user', 'wrong_password')
+    response = get_auth_token(client, 'test_user@test.com', 'wrong_password')
     assert(response.status_code == 401)
 
 def test_access_valid_auth_token(client):
-    response = get_auth_token(client, 'test_user', 'test_password')
+    response = get_auth_token(client, 'test_user@test.com', 'test_password')
     response = client.get('/api/v0.1/test/protected', headers={
         'Authorization': 'Bearer {}'.format(response.get_json()['auth_token'])
     })
     assert(response.status_code == 200)
 
 def test_access_invalid_auth_token(client):
-    response = get_auth_token(client, 'test_user', 'test_password')
+    response = get_auth_token(client, 'test_user@test.com', 'test_password')
     response = client.get('/api/v0.1/test/protected', headers={
         'Authorization': 'Bearer {}'.format('Invalid auth token')
     })
@@ -85,7 +82,7 @@ def test_access_expired_auth_token():
 
     client = app.test_client()
 
-    response = get_auth_token(client, 'test_user', 'test_password')
+    response = get_auth_token(client, 'test_user@test.com', 'test_password')
     time.sleep(1)
     response = client.get('/api/v0.1/test/protected', headers={
         'Authorization': 'Bearer {}'.format(response.get_json()['auth_token'])


### PR DESCRIPTION
This includes changes to endpoint signatures to no longer have a 'username' field. All instances of 'email address' as a json field were replaced with 'email' to sync with other endpoints. 

Changes are reflected in the design doc and test cases. requesting review from front-end folks @hmarcks and @maxkwallace because of API changes.